### PR TITLE
Change related IDs to be unsigned [fixes #5]

### DIFF
--- a/migrations/2012_06_17_211339_init.php
+++ b/migrations/2012_06_17_211339_init.php
@@ -56,7 +56,7 @@ class Verify_Init {
 			$table->string('password', 60)->index();
 			$table->string('salt', 32);
 			$table->string('email', 255)->index();
-			$table->integer('role_id')->index();
+			$table->integer('role_id')->unsigned()->index();
 			$table->boolean('verified');
 			$table->boolean('disabled');
 			$table->boolean('deleted');
@@ -70,8 +70,8 @@ class Verify_Init {
 			$table->engine = 'InnoDB';
 
 			$table->increments('id');
-			$table->integer('permission_id');
-			$table->integer('role_id');
+			$table->integer('permission_id')->unsigned()->index();
+			$table->integer('role_id')->unsigned()->index();
 			$table->timestamps();
 
 			$table->foreign('permission_id')->references('id')->on(VERIFY_PREFIX.'permissions');


### PR DESCRIPTION
`$table->increments('id');` will create an unsigned integer automatically, along with auto increment and the primary key index. For a foreign key to be created, the child column must match the parent type exactly.

`INT` on its own will use 11 as the default length. By telling Laravel we want our indexes unsigned too, the columns now match the parent column types. There were a couple indexes missing too so I've added those in where needed.
